### PR TITLE
feat: add support for tag generation for specific major version

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,12 @@ Release scripts for all of Escale's workflows
 ## Usage
 
 ```sh
-npx github:escaletech/releaser [--update-package-json]
+npx github:escaletech/releaser [--update-package-json] [--major-version <version>]
 ```
 
 ### Options
 * `--update-package-json`: pass this option if you want the releaser to update the version number in your `package.json` file. ⚠️ **Only use this option for releasing NPM packages, not applications.**
+* `--major-version`: pass this option followed by a major version number to generate a tag specifically for a major version.
 
 ### Node.js shortcut
 

--- a/bin/release.js
+++ b/bin/release.js
@@ -14,10 +14,11 @@ const {
 async function main () {
   const dryRun = argv.d || argv['dry-run']
   const shouldUpdatePackageJson = argv['update-package-json']
+  const majorVersion = argv['major-version']
 
   await fetchUpdates({ dryRun })
 
-  const lastTag = await lookForLastTag()
+  const lastTag = await lookForLastTag({ majorVersion })
 
   await printChanges({ lastTag })
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -8,9 +8,9 @@ const DotJson = require('dot-json')
 const { listCommits } = require('./commits')
 const { getLastTag } = require('./tags')
 
-function lookForLastTag () {
+function lookForLastTag ({ majorVersion }) {
   console.log(`${chalk.bold.yellow('…')} Looking for the next tag`)
-  return getLastTag()
+  return getLastTag({ majorVersion })
 }
 
 async function printChanges ({ lastTag }) {

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -3,8 +3,9 @@ const getTags = promisify(require('git-semver-tags'))
 const { major, inc } = require('semver')
 const getRecommendedBump = promisify(require('conventional-recommended-bump'))
 
-async function getLastTag () {
+async function getLastTag ({ majorVersion }) {
   const allTags = await getTags()
+  if (majorVersion) return allTags.find(tag => tag.indexOf(majorVersion) === 1) || ''
   return allTags[0] || ''
 }
 

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -5,7 +5,7 @@ const getRecommendedBump = promisify(require('conventional-recommended-bump'))
 
 async function getLastTag ({ majorVersion }) {
   const allTags = await getTags()
-  if (majorVersion) return allTags.find(tag => tag.indexOf(majorVersion) === 1) || ''
+  if (majorVersion !== undefined) return allTags.find(tag => tag.indexOf(majorVersion) === 1) || ''
   return allTags[0] || ''
 }
 

--- a/tag-and-push.sh
+++ b/tag-and-push.sh
@@ -1,2 +1,2 @@
 #! /bin/bash
-npx github:escaletech/releaser
+npx github:escaletech/releaser $*


### PR DESCRIPTION
This PR enables Releaser to be used to generate tags for specific major versions.

### Usage
Use the `major-version` option to generate a tag specifically for a major version.

Example:
```sh
npx github:escaletech/releaser --major-version 1
```
