### PR TITLE
feat: allow gpg sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ Release scripts for all of Escale's workflows
 ## Usage
 
 ```sh
-npx github:escaletech/releaser [--update-package-json] [--major-version <version>]
+npx github:escaletech/releaser [--update-package-json] [--major-version <version>] [--gpg-sign]
 ```
 
 ### Options
 * `--update-package-json`: pass this option if you want the releaser to update the version number in your `package.json` file. ⚠️ **Only use this option for releasing NPM packages, not applications.**
 * `--major-version`: pass this option followed by a major version number to generate a tag specifically for a major version.
+* `--gpg-sign`: pass this option to GPG sign your generated tags.
 
 ### Node.js shortcut
 

--- a/bin/release.js
+++ b/bin/release.js
@@ -15,6 +15,7 @@ async function main () {
   const dryRun = argv.d || argv['dry-run']
   const shouldUpdatePackageJson = argv['update-package-json']
   const majorVersion = argv['major-version']
+  const gpgSign = argv['gpg-sign']
 
   await fetchUpdates({ dryRun })
 
@@ -30,7 +31,7 @@ async function main () {
     await updatePackageJson({ nextTag, dryRun })
   }
 
-  await applyTagAndPush({ nextTag, dryRun })
+  await applyTagAndPush({ nextTag, dryRun, gpgSign })
 }
 
 main()

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -59,10 +59,14 @@ async function updatePackageJson ({ nextTag, dryRun }) {
   }
 }
 
-async function applyTagAndPush ({ nextTag, dryRun }) {
+async function applyTagAndPush ({ nextTag, dryRun, gpgSign }) {
   console.log(`${chalk.bold.yellow('…')} Creating tag`)
+  let args = nextTag
+  if (gpgSign) {
+    args = `-s ${nextTag}`
+  }
   if (!dryRun) {
-    await runCommand(`git tag ${nextTag}`)
+    await runCommand(`git tag ${args}`)
   }
 
   console.log(`${chalk.bold.yellow('…')} Pushing to origin`)


### PR DESCRIPTION
Adds --gpg-sign optional parameter to releaser.
When specified, it adds a -s parameter to git tag command. If you have
your gpg key setted up in your local environment & your public key on
github, your releases will be marked as *verified* with you own personal
gpg key.