### PR TITLE
fix: sign (-s) requires message (-m)

### DIFF
--- a/lib/steps.js
+++ b/lib/steps.js
@@ -63,7 +63,7 @@ async function applyTagAndPush ({ nextTag, dryRun, gpgSign }) {
   console.log(`${chalk.bold.yellow('…')} Creating tag`)
   let args = nextTag
   if (gpgSign) {
-    args = `-s ${nextTag}`
+    args = `-s ${nextTag} -m ${nextTag}`
   }
   if (!dryRun) {
     await runCommand(`git tag ${args}`)


### PR DESCRIPTION
As in git tag documentation, -s requires a git message.
This commits adds a message containing the git tag for when --gpg-sign
is invoked.