### PR TITLE
fix: get always the latest tag

### DIFF
--- a/lib/tags.js
+++ b/lib/tags.js
@@ -1,11 +1,13 @@
 const { promisify } = require('util')
 const getTags = promisify(require('git-semver-tags'))
+const semverSort = require('semver-sort')
 const { major, inc } = require('semver')
 const getRecommendedBump = promisify(require('conventional-recommended-bump'))
 
 async function getLastTag ({ majorVersion }) {
   const allTags = await getTags()
   if (majorVersion !== undefined) return allTags.find(tag => tag.indexOf(majorVersion) === 1) || ''
+  semverSort.desc(allTags)
   return allTags[0] || ''
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "requires": true,
   "packages": {
     "": {
-      "version": "0.4.1",
+      "version": "0.4.2",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.0",
@@ -17,6 +17,7 @@
         "git-semver-tags": "^4.0.0",
         "prompts": "^2.3.2",
         "semver": "^7.3.2",
+        "semver-sort": "^0.0.4",
         "yargs": "^15.4.0"
       },
       "bin": {
@@ -7076,6 +7077,34 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
+      "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk=",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver-sort": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/semver-sort/-/semver-sort-0.0.4.tgz",
+      "integrity": "sha1-NP293GprK0FhOYw8TbpWJDv+qos=",
+      "dependencies": {
+        "semver": "^5.0.3",
+        "semver-regex": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/semver-sort/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -14118,6 +14147,27 @@
       "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
       "requires": {
         "lru-cache": "^6.0.0"
+      }
+    },
+    "semver-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-1.0.0.tgz",
+      "integrity": "sha1-kqSWkGX5xwxpR1PVUkj8aPj2Usk="
+    },
+    "semver-sort": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/semver-sort/-/semver-sort-0.0.4.tgz",
+      "integrity": "sha1-NP293GprK0FhOYw8TbpWJDv+qos=",
+      "requires": {
+        "semver": "^5.0.3",
+        "semver-regex": "^1.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
       }
     },
     "set-blocking": {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "git-semver-tags": "^4.0.0",
     "prompts": "^2.3.2",
     "semver": "^7.3.2",
+    "semver-sort": "^0.0.4",
     "yargs": "^15.4.0"
   },
   "standard": {


### PR DESCRIPTION
tags from git was not properly sorted, so in some situations it was not
getting latest tag.

`semver-sort` seems to do exacly this: proper sort tags, allowing us to
match the latest tag, fixing releaser bug.